### PR TITLE
Only allow staff members to authenticate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- require "employee" value in eduPersonAffiliation
+
 ## [1.0.1] - 2024-06-04
 - enable JSON logging and LOG_LEVEL environment variable
 - add production configuration

--- a/docker/oidc-test-client/app.py
+++ b/docker/oidc-test-client/app.py
@@ -68,6 +68,12 @@ def oidc_callback():
 
     assert aresp["state"] == session["state"]
 
+    if "error" in aresp:
+        return jsonify(
+            error_response=aresp.to_dict(),
+        )
+
+
     code = aresp["code"]
     logging.info("got auth code=%s", code)
 

--- a/src/satosa/internal_attributes.yaml
+++ b/src/satosa/internal_attributes.yaml
@@ -25,6 +25,9 @@ attributes:
   eppn:
     saml:
       - eduPersonPrincipalName
+  eduPersonAffiliation:
+    saml:
+      - eduPersonAffiliation
   uid:
     openid:
       - uid

--- a/src/satosa/plugins/microservices/attribute_authorization.yaml
+++ b/src/satosa/plugins/microservices/attribute_authorization.yaml
@@ -1,0 +1,9 @@
+module: satosa.micro_services.attribute_authorization.AttributeAuthorization
+name: AttributeAuthorization
+config:
+  force_attributes_presence_on_allow: true
+  attribute_allow:
+    default: # any requester (SP/RP)
+      default: # any issuer (IdP/OP)
+        eduPersonAffiliation:
+          - "^employee$"

--- a/src/satosa/proxy_conf.yaml
+++ b/src/satosa/proxy_conf.yaml
@@ -12,6 +12,7 @@ FRONTEND_MODULES:
   - plugins/frontends/openid_connect_frontend.yaml
   - plugins/frontends/ping_frontend.yaml
 MICRO_SERVICES:
+  - plugins/microservices/attribute_authorization.yaml
   - plugins/microservices/primary_identifier.yaml
   - plugins/microservices/static_attributes.yaml
   - plugins/microservices/attribute_processor.yaml

--- a/src/satosa/tests/test_e2e.py
+++ b/src/satosa/tests/test_e2e.py
@@ -13,7 +13,9 @@ def browser_context_args():
 def renater_test_idp(page):
     page.get_by_label("Nom d'utilisateur").fill("etudiant1")
     page.get_by_label("Mot de passe").fill("etudiant1")
+    page.get_by_label("Afficher les informations qui vont être transférées").check()
     page.get_by_role("button", name="Connexion").click()
+    page.get_by_role("button", name="Accepter").click()
 
 
 def renater_wayf(page):


### PR DESCRIPTION
## Purpose

As requested, we should only allow users identified as employees to authenticate.

## Proposal

We use the `eduPersonAffiliation` attribute: https://services.renater.fr/documentation/supann/supann2021/recommandations/attributs/edupersonaffiliation
