### PR TITLE
🚀(logging) enable JSON logs and LOG_LEVEL env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - env.d/development/satosa
     volumes:
       - ./src/satosa:/app
+      - ./docker/files/usr/local/etc/gunicorn/satosa.py:/usr/local/etc/gunicorn/satosa.py
     depends_on:
       - redis
 

--- a/docker/files/usr/local/etc/gunicorn/satosa.py
+++ b/docker/files/usr/local/etc/gunicorn/satosa.py
@@ -1,3 +1,65 @@
+import datetime
+import logging
+import os
+import sys
+
+import json_log_formatter
+
+
+class RequestJSONFormatter(json_log_formatter.JSONFormatter):
+    """
+    Converts Gunicorn request log records to JSON.
+
+    See https://docs.gunicorn.org/en/stable/settings.html#access-log-format
+    """
+
+    def json_record(
+        self,
+        message: str,
+        extra: dict[str, str | int | float],
+        record: logging.LogRecord,
+    ) -> dict[str, str | int | float]:
+        # Convert the log record to a JSON object.
+
+        response_time = datetime.datetime.strptime(
+            record.args["t"], "[%d/%b/%Y:%H:%M:%S %z]"
+        )
+        url = record.args["U"]
+        if record.args["q"]:
+            url += f"?{record.args['q']}"
+
+        return {
+            "remote_ip": record.args["h"],
+            "method": record.args["m"],
+            "path": url,
+            "status": str(record.args["s"]),
+            "time": response_time.isoformat(),
+            "user_agent": record.args["a"],
+            "referer": record.args["f"],
+            "duration_in_ms": record.args["M"],
+            "poppid": record.process,
+        }
+
+
+class DefaultJSONFormatter(json_log_formatter.JSONFormatter):
+    """
+    Formats a log record as JSON, adding level and pid.
+    """
+
+    def json_record(
+        self,
+        message: str,
+        extra: dict[str, str | int | float],
+        record: logging.LogRecord,
+    ) -> dict[str, str | int | float]:
+        payload: dict[str, str | int | float] = super().json_record(
+            message, extra, record
+        )
+        payload["level"] = record.levelname
+        payload["pid"] = record.process
+        return payload
+
+
 bind = ["0.0.0.0:8000"]
 name = "satosa"
 python_path = "/app"
@@ -11,4 +73,47 @@ timeout = 90
 accesslog = "-"
 # Using '-' for the error log file makes gunicorn log errors to stderr
 errorlog = "-"
-loglevel = "info"
+loglevel = os.environ.get("LOG_LEVEL", "INFO")
+
+logconfig_dict = {
+    "version": 1,
+    "disable_existing_loggers": True,
+    "root": {"level": loglevel.upper(), "handlers": ["json_error"]},
+    "loggers": {
+        # The gunicorn.error and gunicorn.access loggers are preconfigured with
+        # a handler and propagate=False, we need to override this with the
+        # default values (no handlers and propagate=True)
+        "gunicorn.error": {
+            "level": "INFO",
+            "handlers": ["json_error"],
+            "propagate": False,
+            "qualname": "gunicorn.error",
+        },
+        "gunicorn.access": {
+            "level": "INFO",
+            "handlers": ["json_request"],
+            "propagate": False,
+            "qualname": "gunicorn.access",
+        },
+    },
+    "formatters": {
+        "json_request": {
+            "()": RequestJSONFormatter,
+        },
+        "json_error": {
+            "()": DefaultJSONFormatter,
+        },
+    },
+    "handlers": {
+        "json_request": {
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+            "formatter": "json_request",
+        },
+        "json_error": {
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+            "formatter": "json_error",
+        },
+    },
+}

--- a/src/helm/env.d/dev/values.oidc2fer.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.oidc2fer.yaml.gotmpl
@@ -9,6 +9,8 @@ satosa:
     BASE_URL: https://oidc2fer.127.0.0.1.nip.io
     GUNICORN_CMD_ARGS: --workers=3
 
+    LOG_LEVEL: debug
+
     SAML2_DISCOVERY_URL: https://discovery.renater.fr/test/
     SAML2_METADATA_URL: https://pub.federation.renater.fr/metadata/test/preview/preview-idps-test-metadata.xml
 

--- a/src/helm/env.d/outscale-production/values.oidc2fer.yaml.gotmpl
+++ b/src/helm/env.d/outscale-production/values.oidc2fer.yaml.gotmpl
@@ -9,6 +9,8 @@ satosa:
     BASE_URL: https://renater.agentconnect.gouv.fr
     GUNICORN_CMD_ARGS: --workers=3
 
+    LOG_LEVEL: info
+
     SAML2_DISCOVERY_URL: https://discovery.renater.fr/renater
     SAML2_METADATA_URL: https://pub.federation.renater.fr/metadata/renater/main/main-idps-renater-metadata.xml
 

--- a/src/helm/env.d/staging/values.oidc2fer.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.oidc2fer.yaml.gotmpl
@@ -9,6 +9,8 @@ satosa:
     BASE_URL: https://oidc2fer-staging.beta.numerique.gouv.fr
     GUNICORN_CMD_ARGS: --workers=3
 
+    LOG_LEVEL: debug
+
     SAML2_DISCOVERY_URL: https://discovery.renater.fr/test/
     SAML2_METADATA_URL: https://pub.federation.renater.fr/metadata/test/preview/preview-idps-test-metadata.xml
 

--- a/src/satosa/proxy_conf.yaml
+++ b/src/satosa/proxy_conf.yaml
@@ -16,28 +16,7 @@ MICRO_SERVICES:
   - plugins/microservices/static_attributes.yaml
   - plugins/microservices/attribute_processor.yaml
 LOGGING:
+  # All the logging configuration is done in the Gunicorn config, this is just
+  # here to avoid overwriting it with the default SATOSA config
   version: 1
-  formatters:
-    simple:
-      format: '[%(asctime)s] [%(levelname)s] [%(name)s.%(funcName)s] %(message)s'
-  handlers:
-    stdout:
-      class: logging.StreamHandler
-      stream: ext://sys.stdout
-      level: DEBUG
-      formatter: simple
-  loggers:
-    satosa:
-      level: DEBUG
-    saml2:
-      level: DEBUG
-    oidcendpoint:
-      level: DEBUG
-    pyop:
-      level: DEBUG
-    oic:
-      level: DEBUG
-  root:
-    level: DEBUG
-    handlers:
-      - stdout
+  incremental: true

--- a/src/satosa/pyproject.toml
+++ b/src/satosa/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "SATOSA==8.4.0",
     "gunicorn==22.0.0",
     "redis==5.0.4",
+    "JSON-log-formatter==1.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
All logs (Gunicorn + SATOSA) are now logged as JSON and the level can be controlled with the LOG_LEVEL environment variable.