### PR TITLE
🔒️(saml) check the scope of the eduPersonPrincipalName attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- check the scope of returned eduPersonPrincipalNames
 - require "employee" value in eduPersonAffiliation
 
 ## [1.0.1] - 2024-06-04

--- a/src/satosa/internal_attributes.yaml
+++ b/src/satosa/internal_attributes.yaml
@@ -22,7 +22,7 @@ attributes:
   acr:
     openid:
       - acr
-  eppn:
+  eduPersonPrincipalName:
     saml:
       - eduPersonPrincipalName
   eduPersonAffiliation:

--- a/src/satosa/plugins/microservices/attribute_authorization.yaml
+++ b/src/satosa/plugins/microservices/attribute_authorization.yaml
@@ -5,5 +5,12 @@ config:
   attribute_allow:
     default: # any requester (SP/RP)
       default: # any issuer (IdP/OP)
+        eduPersonPrincipalName:
+          # The eduPersonPrincipalName value may have been filtered by the
+          # AttributeFilter processor, if it did not match an expected scope
+          # for the IdP.
+          # We require it to be non-empty here, to avoid an unhandled error
+          # later in the PrimaryIdentifier processor.
+          - ".+"
         eduPersonAffiliation:
           - "^employee$"

--- a/src/satosa/plugins/microservices/filter_attributes.yaml
+++ b/src/satosa/plugins/microservices/filter_attributes.yaml
@@ -1,0 +1,12 @@
+module: satosa.micro_services.attribute_modifications.FilterAttributeValues
+name: AttributeFilter
+config:
+    attribute_filters:
+        # default rules for any IdentityProvider
+        "":
+            # default rules for any requester
+            "":
+                eduPersonPrincipalName:
+                    # enforce correct scope (the part after '@' must match one
+                    # of the scopes declared in the metadata)
+                    shibmdscope_match_scope:

--- a/src/satosa/plugins/microservices/primary_identifier.yaml
+++ b/src/satosa/plugins/microservices/primary_identifier.yaml
@@ -7,7 +7,7 @@ config:
     # names are the internal SATOSA names for the attributes as
     # defined in internal_attributes.yaml.
     ordered_identifier_candidates:
-        - attribute_names: [eppn]
+        - attribute_names: [eduPersonPrincipalName]
 
     # The internal SATOSA attribute into which to place the primary
     # identifier value once found from the above configured ordered

--- a/src/satosa/proxy_conf.yaml
+++ b/src/satosa/proxy_conf.yaml
@@ -12,6 +12,7 @@ FRONTEND_MODULES:
   - plugins/frontends/openid_connect_frontend.yaml
   - plugins/frontends/ping_frontend.yaml
 MICRO_SERVICES:
+  - plugins/microservices/filter_attributes.yaml
   - plugins/microservices/attribute_authorization.yaml
   - plugins/microservices/primary_identifier.yaml
   - plugins/microservices/static_attributes.yaml

--- a/src/satosa/tests/test_e2e.py
+++ b/src/satosa/tests/test_e2e.py
@@ -125,4 +125,4 @@ def test_agent_connect_to_renater_student_not_allowed(page: Page):
     renater_wayf(page)
     renater_test_idp(page, login="etudiant1")
 
-    expect(page.locator("body")).to_contain_text("access_denied")
+    expect(page.locator("body")).to_contain_text("Une erreur technique est survenue.")


### PR DESCRIPTION
## Proposal

The metadata obtained from the federation server contains a list of allowed scopes for each of the registered identity providers.

By checking the value of the `eduPersonPrincipalName` attribute returned by an IdP against the allowed scopes for that IdP, we protect the downstream services against identity theft by a compromised IdP.
