### PR TITLE
Upgrade SAML signature algorithm for interoperability with RENATER Access Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- set SAML signing algorithm to use SHA256 for compatibility with AccessCheck
+
 ## [1.0.2] - 2024-07-22
 - check the scope of returned eduPersonPrincipalNames
 - require "employee" value in eduPersonAffiliation

--- a/src/satosa/plugins/backends/saml2_backend.yaml
+++ b/src/satosa/plugins/backends/saml2_backend.yaml
@@ -38,6 +38,7 @@ config:
             height: '200'
         authn_requests_signed: true
         want_response_signed: true
+        signing_algorithm: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
         allow_unsolicited: true
         name_id_format:
           - urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress


### PR DESCRIPTION
## Problem

Currently when we try to login using [RENATER Access Check](https://access-check.renater.fr) we get a 500 error from Access Check:

![image](https://github.com/user-attachments/assets/e7c56a35-a436-49f5-91d5-f57613aab3a0)

After asking the RENATER people to look into the logs, it appeared to be a signature issue.

I first checked to make sure the certificate used to sign the requests was the same as the one advertised in the metadata, but could not find a discrepancy there.

Then I tried to manually check the signature for the authentication requests we were sending to the IdP. The signature checked out, but I noticed it was using a SHA-1-based signature method (`http://www.w3.org/2000/09/xmldsig#sha1`). Because SHA-1 is generally deprecated, I suspected this might be why the signature was rejected.

So I tried overriding the signature method with `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` (whose support is required by the XML Signature Recommendation [since 2013](https://www.w3.org/TR/2013/REC-xmldsig-core1-20130411/)). And indeed, this let our signed requests be accepted by Access Check.

## Proposal

Use `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` as the signature method for all requests to an IdP.
