### PR TITLE
🔧(helm) add pdbs to deployements

### DIFF
--- a/src/helm/oidc2fer/templates/satosa_deployment.yaml
+++ b/src/helm/oidc2fer/templates/satosa_deployment.yaml
@@ -82,3 +82,16 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+---
+{{ if .Values.satosa.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "oidc2fer.common.selectorLabels" (list . $component) | nindent 6 }}
+{{ end }}

--- a/src/helm/oidc2fer/values.yaml
+++ b/src/helm/oidc2fer/values.yaml
@@ -52,6 +52,10 @@ ingress:
 
 satosa:
 
+  ## @param satosa.pdb.enabled Enable pdb on backend
+  pdb:
+    enabled: true
+
   ## @param satosa.command Override the satosa container command
   command: []
 


### PR DESCRIPTION
In order to avoid a service interruption during a Kubernetes (k8s)upgrade, we add a Pod Disruption Budget (PDB) to deployments.