### PR TITLE
🔒️(nginx) add basic path allowlist to block random attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- add allowlist for URL paths to nginx ingress
+
 ## [1.0.4] - 2024-09-11
 - serve static files
 

--- a/src/helm/oidc2fer/templates/ingress.yaml
+++ b/src/helm/oidc2fer/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "oidc2fer.fullname" . -}}
+{{- $port := .Values.satosa.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -33,13 +34,15 @@ spec:
     - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .Values.ingress.paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "oidc2fer.satosa.fullname" . }}
+                name: {{ $fullName }}-satosa
                 port:
-                  number: {{ .Values.satosa.service.port }}
+                  number: {{ $port }}
+          {{- end }}
           {{- with .Values.ingress.customBackends }}
             {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/src/helm/oidc2fer/values.yaml
+++ b/src/helm/oidc2fer/values.yaml
@@ -33,7 +33,9 @@ ingress:
   enabled: false
   className: null
   host: oidc2fer.example.com
-  path: /
+  paths:
+  - path: '/$|^/\.well-known/openid-configuration$|^/images/|^/Saml2/|^/OIDC/|^/ping$'
+    pathType: ImplementationSpecific # enables regex matching
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
@@ -47,6 +49,9 @@ ingress:
 
   ## @param ingress.customBackends Add custom backends to ingress
   customBackends: []
+
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
 
 ## @section satosa
 


### PR DESCRIPTION
## Purpose

Looking at the request logs, we can see numerous requests to paths corresponding to vulnerabilities in other applications, such as `/admin/uploads.php`, `/ajaxPages/writeBrowseFilePathAjax.php` and so on.

## Proposal

This PR adds to the ingress configuration a limited list of URL paths that will be mapped to the gunicorn pods.

This should cut down on opportunistic attack attempts, which are more a nuisance than anything right now but it can't hurt to stop them earlier.

A proper WAF setup in front of the app would be stronger but this is an inexpensive step that we can do right now.