### PR TITLE
🚀(logging) allow customizing log levels per logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ## Unreleased
 - add allowlist for URL paths to nginx ingress
+- allow customizing log levels per logger
 
 ## [1.0.4] - 2024-09-11
 - serve static files

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ number and date.
 3. Commit and push to `main`.
 4. Update the `production` tag and push it.
 
+## Environment variables
+
+| variable | usage |
+| --- | --- |
+| `LOG_LEVEL` | Sets the log level for the root logger, i.e. the default. Defaults to `INFO`. |
+| `LOG_LEVELS` | A JSON object that can be used to set log levels for specific loggers, e.g. `{"satosa.backends.saml2": "DEBUG"}`. Defaults to `{}`. |
+
 ## Contributing
 
 This project is intended to be community-driven, so please, do not hesitate to

--- a/src/helm/env.d/outscale-production/values.oidc2fer.yaml.gotmpl
+++ b/src/helm/env.d/outscale-production/values.oidc2fer.yaml.gotmpl
@@ -9,7 +9,8 @@ satosa:
     BASE_URL: https://renater.agentconnect.gouv.fr
     GUNICORN_CMD_ARGS: --workers=3
 
-    LOG_LEVEL: info
+    LOG_LEVEL: INFO
+    LOG_LEVELS: '{ "satosa.backends.saml2": "DEBUG" }'
 
     SAML2_DISCOVERY_URL: https://discovery.renater.fr/agentconnect/
     SAML2_METADATA_URL: https://pub.federation.renater.fr/metadata/renater/main/main-idps-renater-metadata.xml

--- a/src/helm/env.d/staging/values.oidc2fer.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.oidc2fer.yaml.gotmpl
@@ -9,7 +9,8 @@ satosa:
     BASE_URL: https://oidc2fer-staging.beta.numerique.gouv.fr
     GUNICORN_CMD_ARGS: --workers=3
 
-    LOG_LEVEL: debug
+    LOG_LEVEL: DEBUG
+    LOG_LEVELS: '{ "satosa.backends.saml2": "DEBUG" }'
 
     SAML2_DISCOVERY_URL: https://discovery.renater.fr/test/
     SAML2_METADATA_URL: https://pub.federation.renater.fr/metadata/test/preview/preview-idps-test-metadata.xml


### PR DESCRIPTION
This lets one enable increased logging at a finer level. For example, one could enable debug logging for a specific logger, while keeping the rest of the application at info level.

Also, by default `/ping` requests are excluded from the logs.