### PR TITLE
Remove unused APT dependencies that trigger a CVE warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- remove unused APT dependencies
+- upgrade to gunicorn 23.0.0
+
 ## [1.0.6] - 2025-03-11
 - upgrade to SATOSA 8.5.1
 - allow faculty, staff, employee, researcher, teacher affiliations

--- a/src/satosa/pyproject.toml
+++ b/src/satosa/pyproject.toml
@@ -24,7 +24,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "SATOSA==8.5.1",
-    "gunicorn==22.0.0",
+    "gunicorn==23.0.0",
     "redis==5.0.4",
     "JSON-log-formatter==1.0",
     "WhiteNoise==6.7.0",


### PR DESCRIPTION
## Purpose

Prevent the Docker image from being flagged as having security issues.

## Proposal

Specifically CVE-2023-45853 was flagged in our Docker image, but it is in libfreetype6 which we don't use, and is only pulled in because of a recommended depdency of `gcc` — which we don't need in any case.

Also bump gunicorn to `23.0.0` as suggested by Dependabot.